### PR TITLE
Correct map url in index html

### DIFF
--- a/images/index.html
+++ b/images/index.html
@@ -166,7 +166,7 @@
                  <label class="block text-sm font-medium text-slate-100 mb-1">2. Public URL Details (Optional)</label>
                  <p class="text-xs text-slate-300 mb-2">Fill these in to generate a full public URL for each media item.</p>
                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                     <input type="text" id="org-domain" value="https://map.marknanthony.com" placeholder="Org Domain (e.g., https://...)" class="w-full p-3 bg-white/10 border border-white/30 rounded-md text-white placeholder-slate-300 focus:ring-2 focus:ring-white/50 focus:border-white/50 transition">
+                     <input type="text" id="org-domain" value="https://map.markanthony.com" placeholder="Org Domain (e.g., https://...)" class="w-full p-3 bg-white/10 border border-white/30 rounded-md text-white placeholder-slate-300 focus:ring-2 focus:ring-white/50 focus:border-white/50 transition">
                      <input type="text" id="channel-id" value="0apOM0000000F2I" placeholder="Channel ID (15 Characters)" class="w-full p-3 bg-white/10 border border-white/30 rounded-md text-white placeholder-slate-300 focus:ring-2 focus:ring-white/50 focus:border-white/50 transition">
                      <input type="text" id="org-id" value="00Dau0000029vab" placeholder="Org ID (e.g., 00D...)" class="w-full p-3 bg-white/10 border border-white/30 rounded-md text-white placeholder-slate-300 focus:ring-2 focus:ring-white/50 focus:border-white/50 transition sm:col-span-2">
                  </div>


### PR DESCRIPTION
Corrected a typo in the default 'Org Domain' URL in `images/index.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f044f4ca-2230-4815-b84b-29202923314e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f044f4ca-2230-4815-b84b-29202923314e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

